### PR TITLE
Fix next build problem

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - '4000:4000'
     volumes:
       - ./web-app:/web-app
+      - /web-app/node_modules
+      - /web-app/.next
     working_dir: /web-app
     environment:
       - NODE_ENV=production


### PR DESCRIPTION
- After running `docker compose build`, the `node_modules` and `.next` folders are created instide container, but after running `docker compose up - d`, volumes from `docker-compose.yml` are mounted, and since the host does not have these folders, they are mounted without them, so the container does not see theirs.

Docker内部でフォルダは生成されるが、マウントしないとホスト側に吐き出されないためアプリケーション実行時`docker compose up`にホスト側に存在しなくなってしまう。

(https://stackoverflow.com/questions/77519270/problem-with-deploying-next-js-app-on-docker)
